### PR TITLE
Mirror pylint 1.4.5 to fix broken pylint / astroid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ from setuptools import setup
 setup(
     name='__dummy_package',
     version='0.0.0',
-    install_requires=['pylint==1.4.3'],
+    install_requires=['pylint==1.4.5'],
 )


### PR DESCRIPTION
Per https://bitbucket.org/logilab/pylint/issues/720 pylint / astroid compatibility requires either
  pylint >= 1.5 + astroid >= 1.4
OR
 pylint < 1.5 + astroid < 1.4

(pylint 1.4.x + astroid 1.4.x causes, all variables to get E0602 (undefined-variable).due to
"Problem importing module classes.py: cannot import name 'InferenceContext'")

Mirroring pylint 1.4.3 is broken now that astroid 1.4.0 is available,
but pylint 1.4.5 will work, since that explicitly requires astroid<1.4