### PR TITLE
Point to the correct link for the pylint repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mirror of pylint package for pre-commit.
 
 For pre-commit: see https://github.com/pre-commit/pre-commit
 
-For pylint: see https://bitbucket.org/logilab/pylint/
+For pylint: see https://github.com/pycqa/pylint
 
 
 ### Using pylint with pre-commit


### PR DESCRIPTION
Pylint is hosted on github under the PyCQA organisation and it's no longer on bitbucket.